### PR TITLE
fix: add examples in storybook

### DIFF
--- a/src/components/GridItem.vue
+++ b/src/components/GridItem.vue
@@ -887,6 +887,7 @@
         resizableAndNotStatic,
         resizableHandleClass,
         classObj,
+        calcXY,
       };
     },
   });

--- a/src/components/GridLayout.vue
+++ b/src/components/GridLayout.vue
@@ -505,7 +505,14 @@
         //Combine the two arrays of unique entries#
         return uniqueResultOne.concat(uniqueResultTwo);
       }
-      return { placeholder, mergedStyle, isDragging, gridLayout, width };
+      return {
+        placeholder,
+        mergedStyle,
+        isDragging,
+        gridLayout,
+        width,
+        dragEvent,
+      };
     },
   });
 </script>

--- a/src/components/examples/AllowIgnore.stories.js
+++ b/src/components/examples/AllowIgnore.stories.js
@@ -1,0 +1,6 @@
+import AllowIgnore from './AllowIgnore.vue';
+export default { title: 'Examples' };
+export const asAComponentWithDragAllowOrIgnoreOnElements = () => ({
+  components: { AllowIgnore },
+  template: `<AllowIgnore/>`,
+});

--- a/src/components/examples/AllowIgnore.vue
+++ b/src/components/examples/AllowIgnore.vue
@@ -1,0 +1,255 @@
+<template>
+  <div>
+    <grid-layout
+      :layout.sync="layout"
+      :col-num="12"
+      :row-height="30"
+      :is-draggable="true"
+      :is-resizable="true"
+      :vertical-compact="true"
+      :use-css-transforms="true"
+    >
+      <grid-item
+        v-for="(item, idx) in layout"
+        :key="idx"
+        :x="item.x"
+        :y="item.y"
+        :w="item.w"
+        :h="item.h"
+        :i="item.i"
+        drag-allow-from=".vue-draggable-handle"
+        drag-ignore-from=".no-drag"
+      >
+        <div class="text">
+          <div class="vue-draggable-handle"></div>
+          <div class="no-drag">
+            <span>{{ item.i }}</span>
+            <br />
+            <button>click</button>
+          </div>
+        </div>
+      </grid-item>
+    </grid-layout>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { defineComponent, ref, watch } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      // Event Log
+      const eventLog = ref([]);
+
+      watch(
+        eventLog,
+        () => {
+          const eventsDiv = this.$refs.eventsDiv;
+          eventsDiv.scrollTop = eventsDiv.scrollHeight;
+        },
+        {
+          lazy: true,
+        },
+      );
+
+      //
+
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0' },
+        { x: 2, y: 0, w: 2, h: 4, i: '1' },
+        { x: 4, y: 0, w: 2, h: 5, i: '2' },
+        { x: 6, y: 0, w: 2, h: 3, i: '3' },
+        { x: 8, y: 0, w: 2, h: 3, i: '4' },
+        { x: 10, y: 0, w: 2, h: 3, i: '5' },
+        { x: 0, y: 5, w: 2, h: 5, i: '6' },
+        { x: 2, y: 5, w: 2, h: 5, i: '7' },
+        { x: 4, y: 5, w: 2, h: 5, i: '8' },
+        { x: 6, y: 4, w: 2, h: 4, i: '9' },
+        { x: 8, y: 4, w: 2, h: 4, i: '10' },
+        { x: 10, y: 4, w: 2, h: 4, i: '11' },
+        { x: 0, y: 10, w: 2, h: 5, i: '12' },
+        { x: 2, y: 10, w: 2, h: 5, i: '13' },
+        { x: 4, y: 8, w: 2, h: 4, i: '14' },
+        { x: 6, y: 8, w: 2, h: 4, i: '15' },
+        { x: 8, y: 10, w: 2, h: 5, i: '16' },
+        { x: 10, y: 4, w: 2, h: 2, i: '17' },
+        { x: 0, y: 9, w: 2, h: 3, i: '18' },
+        { x: 2, y: 6, w: 2, h: 2, i: '19' },
+      ]);
+
+      const resizable = ref(true);
+      // Event Resized
+
+      function resizeEvent(i, newH, newW, newHPx, newWPx) {
+        const msg =
+          'RESIZE i=' +
+          i +
+          ', H=' +
+          newH +
+          ', W=' +
+          newW +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      function resizedEvent(i, newX, newY, newHPx, newWPx) {
+        const msg =
+          'RESIZED i=' +
+          i +
+          ', X=' +
+          newX +
+          ', Y=' +
+          newY +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      function containerResizedEvent(i, newH, newW, newHPx, newWPx) {
+        const msg =
+          'CONTAINER RESIZED i=' +
+          i +
+          ', H=' +
+          newH +
+          ', W=' +
+          newW +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      // Layout Event
+
+      function layoutCreatedEvent(newLayout) {
+        eventLog.value.push('Created layout');
+      }
+
+      function layoutReadyEvent(newLayout) {
+        eventLog.value.push('Ready layout');
+      }
+
+      function layoutUpdatedEvent(newLayout) {
+        eventLog.value.push('Updated layout');
+      }
+
+      // Layout Event
+
+      function layoutBeforeMountEvent(newLayout) {
+        eventLog.value.push('beforeMount layout');
+      }
+
+      function layoutMountedEvent(newLayout) {
+        eventLog.value.push('Mounted layout');
+      }
+
+      // Event
+
+      function moveEvent(i, newX, newY) {
+        const msg = 'MOVE i=' + i + ', X=' + newX + ', Y=' + newY;
+        eventLog.value.push(msg);
+      }
+
+      function movedEvent(i, newX, newY) {
+        const msg = 'MOVED i=' + i + ', X=' + newX + ', Y=' + newY;
+        eventLog.value.push(msg);
+      }
+
+      // Misc
+      const draggable = ref(true);
+      const index = ref(0);
+      console.log('layout', layout);
+      return {
+        layout,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    right: 0;
+    padding: 0 8px 8px 0;
+    background-origin: content-box;
+    background-color: black;
+    box-sizing: border-box;
+    border-radius: 10px;
+    cursor: pointer;
+  }
+
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .eventsJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+    height: 100px;
+    overflow-y: scroll;
+  }
+</style>

--- a/src/components/examples/AllowIgnore.vue
+++ b/src/components/examples/AllowIgnore.vue
@@ -47,11 +47,11 @@
     setup() {
       // Event Log
       const eventLog = ref([]);
-
+      const eventsDiv = ref(null);
       watch(
         eventLog,
         () => {
-          const eventsDiv = this.$refs.eventsDiv;
+          const eventsDiv = eventsDiv.value;
           eventsDiv.scrollTop = eventsDiv.scrollHeight;
         },
         {

--- a/src/components/examples/Basic.stories.js
+++ b/src/components/examples/Basic.stories.js
@@ -1,5 +1,5 @@
 import Basic from './Basic.vue';
-export default { title: 'Basic' };
+export default { title: 'Examples' };
 export const asAComponentWithNoDrag = () => ({
   components: { Basic },
   template: `<Basic/>`,

--- a/src/components/examples/DragFromOutside.stories.js
+++ b/src/components/examples/DragFromOutside.stories.js
@@ -1,0 +1,6 @@
+import DragFromOutside from './DragFromOutside.vue';
+export default { title: 'Examples' };
+export const asAComponentWithDragFromOutside = () => ({
+  components: { DragFromOutside },
+  template: `<DragFromOutside/>`,
+});

--- a/src/components/examples/DragFromOutside.vue
+++ b/src/components/examples/DragFromOutside.vue
@@ -69,6 +69,7 @@
       // Mouse X Y
       const mouseXY = { x: null, y: null };
       const gridlayout = ref(null);
+      const colNum = undefined;
 
       onMounted(() => {
         document.addEventListener(
@@ -115,8 +116,8 @@
           layout.value.findIndex((item) => item.i === 'drop') === -1
         ) {
           layout.value.push({
-            x: (layout.value.length * 2) % (this.colNum || 12),
-            y: layout.value.length + (this.colNum || 12), // puts it at the bottom
+            x: (layout.value.length * 2) % (colNum || 12),
+            y: layout.value.length + (colNum || 12), // puts it at the bottom
             w: 1,
             h: 1,
             i: 'drop',
@@ -205,9 +206,9 @@
                       h: 1,
                       i: DragPos.i,
                   });
-                  this.$refs.gridLayout.dragEvent('dragend', DragPos.i, DragPos.x,DragPos.y,1,1);
+                  gridLayout.value.dragEvent('dragend', DragPos.i, DragPos.x,DragPos.y,1,1);
                   try {
-                      this.$refs.gridLayout.$children[layout.value.length].$refs.item.style.display="block";
+                      gridLayout.value.$children[layout.value.length].$refs.item.style.display="block";
                   } catch {
                   }
                   */

--- a/src/components/examples/DragFromOutside.vue
+++ b/src/components/examples/DragFromOutside.vue
@@ -1,0 +1,315 @@
+<template>
+  <div>
+    <div>
+      <div class="layoutJSON">
+        Displayed as <code>[x, y, w, h]</code>:
+        <div class="columns">
+          <div v-for="(item, idx) in layout" :key="idx" class="layoutItem">
+            <b>{{ item.i }}</b
+            >: [{{ item.x }}, {{ item.y }}, {{ item.w }}, {{ item.h }}]
+          </div>
+        </div>
+      </div>
+    </div>
+    <br />
+    <div
+      class="droppable-element"
+      draggable="true"
+      unselectable="on"
+      @drag="drag"
+      @dragend="dragend"
+    >
+      Droppable Element (Drag me!)
+    </div>
+    <div id="content">
+      <grid-layout
+        ref="gridlayout"
+        :layout.sync="layout"
+        :col-num="12"
+        :row-height="30"
+        :is-draggable="true"
+        :is-resizable="true"
+        :vertical-compact="true"
+        :use-css-transforms="true"
+      >
+        <grid-item
+          v-for="item in layout"
+          :key="item.i"
+          :x="item.x"
+          :y="item.y"
+          :w="item.w"
+          :h="item.h"
+          :i="item.i"
+        >
+          <span class="text">{{ item.i }}</span>
+        </grid-item>
+      </grid-layout>
+    </div>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+
+  import {
+    ref,
+    reactive,
+    onMounted,
+    defineComponent,
+  } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      // Mouse X Y
+      const mouseXY = { x: null, y: null };
+      const gridlayout = ref(null);
+
+      onMounted(() => {
+        document.addEventListener(
+          'dragover',
+          function (e) {
+            mouseXY.x = e.clientX;
+            mouseXY.y = e.clientY;
+          },
+          false,
+        );
+      });
+
+      // Misc
+      const DragPos = { x: null, y: null, w: 1, h: 1, i: null };
+
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0' },
+        { x: 2, y: 0, w: 2, h: 4, i: '1' },
+        { x: 4, y: 0, w: 2, h: 5, i: '2' },
+        { x: 6, y: 0, w: 2, h: 3, i: '3' },
+        { x: 8, y: 0, w: 2, h: 3, i: '4' },
+        { x: 10, y: 0, w: 2, h: 3, i: '5' },
+        { x: 0, y: 5, w: 2, h: 5, i: '6' },
+        { x: 2, y: 5, w: 2, h: 5, i: '7' },
+        { x: 4, y: 5, w: 2, h: 5, i: '8' },
+        { x: 5, y: 10, w: 4, h: 3, i: '9' },
+      ]);
+
+      function drag(e) {
+        let parentRect = document
+          .getElementById('content')
+          .getBoundingClientRect();
+        let mouseInGrid = false;
+        if (
+          mouseXY.x > parentRect.left &&
+          mouseXY.x < parentRect.right &&
+          mouseXY.y > parentRect.top &&
+          mouseXY.y < parentRect.bottom
+        ) {
+          mouseInGrid = true;
+        }
+        if (
+          mouseInGrid === true &&
+          layout.value.findIndex((item) => item.i === 'drop') === -1
+        ) {
+          layout.value.push({
+            x: (layout.value.length * 2) % (this.colNum || 12),
+            y: layout.value.length + (this.colNum || 12), // puts it at the bottom
+            w: 1,
+            h: 1,
+            i: 'drop',
+          });
+        }
+        let index = layout.value.findIndex((item) => item.i === 'drop');
+        if (index !== -1) {
+          try {
+            gridlayout.value.$children[
+              layout.value.length
+            ].$refs.item.style.display = 'none';
+          } catch {}
+          let el = gridlayout.value.$children[index];
+          el.dragging = {
+            top: mouseXY.y - parentRect.top,
+            left: mouseXY.x - parentRect.left,
+          };
+          let new_pos = el.calcXY(
+            mouseXY.y - parentRect.top,
+            mouseXY.x - parentRect.left,
+          );
+
+          if (mouseInGrid === true) {
+            gridlayout.value.dragEvent(
+              'dragstart',
+              'drop',
+              new_pos.x,
+              new_pos.y,
+              1,
+              1,
+            );
+            DragPos.i = String(index);
+            DragPos.x = layout.value[index].x;
+            DragPos.y = layout.value[index].y;
+          }
+          if (mouseInGrid === false) {
+            gridlayout.value.dragEvent(
+              'dragend',
+              'drop',
+              new_pos.x,
+              new_pos.y,
+              1,
+              1,
+            );
+            layout.value = layout.value.filter((obj) => obj.i !== 'drop');
+          }
+        }
+      }
+      function dragend(e) {
+        let parentRect = document
+          .getElementById('content')
+          .getBoundingClientRect();
+        let mouseInGrid = false;
+        if (
+          mouseXY.x > parentRect.left &&
+          mouseXY.x < parentRect.right &&
+          mouseXY.y > parentRect.top &&
+          mouseXY.y < parentRect.bottom
+        ) {
+          mouseInGrid = true;
+        }
+        if (mouseInGrid === true) {
+          alert(
+            `Dropped element props:\n${JSON.stringify(
+              DragPos,
+              ['x', 'y', 'w', 'h'],
+              2,
+            )}`,
+          );
+          gridlayout.value.dragEvent(
+            'dragend',
+            'drop',
+            DragPos.x,
+            DragPos.y,
+            1,
+            1,
+          );
+          layout.value = layout.value.filter((obj) => obj.i !== 'drop');
+
+          // UNCOMMENT below if you want to add a grid-item
+          /*
+                  layout.value.push({
+                      x: DragPos.x,
+                      y: DragPos.y,
+                      w: 1,
+                      h: 1,
+                      i: DragPos.i,
+                  });
+                  this.$refs.gridLayout.dragEvent('dragend', DragPos.i, DragPos.x,DragPos.y,1,1);
+                  try {
+                      this.$refs.gridLayout.$children[layout.value.length].$refs.item.style.display="block";
+                  } catch {
+                  }
+                  */
+        }
+      }
+
+      return {
+        gridlayout,
+        layout,
+        drag,
+        dragend,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  .droppable-element {
+    width: 150px;
+    text-align: center;
+    background: #fdd;
+    border: 1px solid black;
+    margin: 10px 0;
+    padding: 10px;
+  }
+
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .columns {
+    -moz-columns: 120px;
+    -webkit-columns: 120px;
+    columns: 120px;
+  }
+</style>

--- a/src/components/examples/DynamicAddRemove.stories.js
+++ b/src/components/examples/DynamicAddRemove.stories.js
@@ -1,0 +1,6 @@
+import DynamicAddRemove from './DynamicAddRemove.vue';
+export default { title: 'Examples' };
+export const asAComponentWithDynamicAddOrRemove = () => ({
+  components: { DynamicAddRemove },
+  template: `<DynamicAddRemove/>`,
+});

--- a/src/components/examples/DynamicAddRemove.vue
+++ b/src/components/examples/DynamicAddRemove.vue
@@ -1,0 +1,188 @@
+<template>
+  <div>
+    <div class="layoutJSON">
+      Displayed as <code>[x, y, w, h]</code>:
+      <div class="columns">
+        <div v-for="item in layout" :key="item.i" class="layoutItem">
+          <b>{{ item.i }}</b
+          >: [{{ item.x }}, {{ item.y }}, {{ item.w }}, {{ item.h }}]
+        </div>
+      </div>
+    </div>
+    <button @click="addItem">Add an item dynamically</button>
+    <input v-model="draggable" type="checkbox" /> Draggable
+    <input v-model="resizable" type="checkbox" /> Resizable
+    <grid-layout
+      :layout.sync="layout"
+      :col-num="colNum"
+      :row-height="30"
+      :is-draggable="draggable"
+      :is-resizable="resizable"
+      :vertical-compact="true"
+      :use-css-transforms="true"
+    >
+      <grid-item
+        v-for="(item, idx) in layout"
+        :key="idx"
+        :static="item.static"
+        :x="item.x"
+        :y="item.y"
+        :w="item.w"
+        :h="item.h"
+        :i="item.i"
+      >
+        <span class="text">{{ item.i }}</span>
+        <span class="remove" @click="removeItem(item.i)">x</span>
+      </grid-item>
+    </grid-layout>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { ref, onMounted, defineComponent } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      // Layout Index
+
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0' },
+        { x: 2, y: 0, w: 2, h: 2, i: '1' },
+        { x: 4, y: 0, w: 2, h: 2, i: '2' },
+        { x: 6, y: 0, w: 2, h: 2, i: '3' },
+        { x: 8, y: 0, w: 2, h: 2, i: '4' },
+      ]);
+
+      onMounted(() => {
+        // this.$gridlayout.load();
+        index.value = layout.value.length;
+      });
+
+      const index = ref(0);
+      // Item
+
+      function addItem() {
+        // Add a new item. It must have a unique key!
+        layout.value.push({
+          x: (layout.value.length * 2) % (colNum.value || 12),
+          y: layout.value.length + (colNum.value || 12), // puts it at the bottom
+          w: 2,
+          h: 2,
+          i: index.value,
+        });
+        // Increment the counter to ensure key is always unique.
+        index.value++;
+      }
+
+      function removeItem(val) {
+        const index = layout.value.map((item) => item.i).indexOf(val);
+        layout.value.splice(index, 1);
+      }
+
+      // Misc
+      const draggable = ref(true);
+      const resizable = ref(true);
+      const colNum = ref(12);
+
+      return {
+        layout,
+        draggable,
+        resizable,
+        colNum,
+        index,
+        addItem,
+        removeItem,
+      };
+    },
+  });
+</script>
+
+<style>
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .columns {
+    -moz-columns: 120px;
+    -webkit-columns: 120px;
+    columns: 120px;
+  }
+
+  /*************************************/
+
+  .remove {
+    position: absolute;
+    right: 2px;
+    top: 0;
+    cursor: pointer;
+  }
+
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/examples/Events.stories.js
+++ b/src/components/examples/Events.stories.js
@@ -1,5 +1,5 @@
 import Events from './Events.vue';
-export default { title: 'Basic' };
+export default { title: 'Examples' };
 export const asAComponentWithEvents = () => ({
   components: { Events },
   template: `<Events/>`,

--- a/src/components/examples/Events.stories.js
+++ b/src/components/examples/Events.stories.js
@@ -1,0 +1,6 @@
+import Events from './Events.vue';
+export default { title: 'Basic' };
+export const asAComponentWithEvents = () => ({
+  components: { Events },
+  template: `<Events/>`,
+});

--- a/src/components/examples/Events.vue
+++ b/src/components/examples/Events.vue
@@ -1,0 +1,284 @@
+<template>
+  <div>
+    <div ref="eventsDiv" class="eventsJSON">
+      <div v-for="(event, idx) in eventLog" :key="idx">
+        {{ event }}
+      </div>
+    </div>
+    <div style="margin-top: 10px">
+      <grid-layout
+        :layout.sync="layout"
+        :col-num="12"
+        :row-height="30"
+        :is-draggable="draggable"
+        :is-resizable="resizable"
+        :vertical-compact="true"
+        :use-css-transforms="true"
+        @layout-created="layoutCreatedEvent"
+        @layout-before-mount="layoutBeforeMountEvent"
+        @layout-mounted="layoutMountedEvent"
+        @layout-ready="layoutReadyEvent"
+        @layout-updated="layoutUpdatedEvent"
+      >
+        <grid-item
+          v-for="(item, idx) in layout"
+          :key="idx"
+          :x="item.x"
+          :y="item.y"
+          :w="item.w"
+          :h="item.h"
+          :i="item.i"
+          @resize="resizeEvent"
+          @move="moveEvent"
+          @resized="resizedEvent"
+          @container-resized="containerResizedEvent"
+          @moved="movedEvent"
+        >
+          <span class="text">{{ item.i }}</span>
+        </grid-item>
+      </grid-layout>
+    </div>
+  </div>
+</template>
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { onMounted, ref, watch } from '@vue/composition-api';
+
+  export default {
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      // Event Log
+      const eventLog = ref([]);
+      const eventsDiv = ref([]);
+
+      watch(
+        eventLog,
+        () => {
+          console.log(
+            'eventsDivwatch',
+            eventsDiv.value.scrollTop,
+            eventsDiv.value.scrollTop,
+          );
+          if (eventsDiv) {
+            eventsDiv.value.scrollTop = eventsDiv.value.scrollHeight;
+          }
+        },
+        {
+          lazy: true,
+        },
+      );
+
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0', static: false },
+        { x: 2, y: 0, w: 2, h: 4, i: '1', static: true },
+        { x: 4, y: 0, w: 2, h: 5, i: '2', static: false },
+        { x: 6, y: 0, w: 2, h: 3, i: '3', static: false },
+        { x: 8, y: 0, w: 2, h: 3, i: '4', static: false },
+        { x: 10, y: 0, w: 2, h: 3, i: '5', static: false },
+        { x: 0, y: 5, w: 2, h: 5, i: '6', static: false },
+        { x: 2, y: 5, w: 2, h: 5, i: '7', static: false },
+        { x: 4, y: 5, w: 2, h: 5, i: '8', static: false },
+        { x: 6, y: 3, w: 2, h: 4, i: '9', static: true },
+        { x: 8, y: 4, w: 2, h: 4, i: '10', static: false },
+        { x: 10, y: 4, w: 2, h: 4, i: '11', static: false },
+        { x: 0, y: 10, w: 2, h: 5, i: '12', static: false },
+        { x: 2, y: 10, w: 2, h: 5, i: '13', static: false },
+        { x: 4, y: 8, w: 2, h: 4, i: '14', static: false },
+        { x: 6, y: 8, w: 2, h: 4, i: '15', static: false },
+        { x: 8, y: 10, w: 2, h: 5, i: '16', static: false },
+        { x: 10, y: 4, w: 2, h: 2, i: '17', static: false },
+        { x: 0, y: 9, w: 2, h: 3, i: '18', static: false },
+        { x: 2, y: 6, w: 2, h: 2, i: '19', static: false },
+      ]);
+
+      const resizable = ref(true);
+      // Event Resized
+
+      function resizeEvent(i, newH, newW, newHPx, newWPx) {
+        const msg =
+          'RESIZE i=' +
+          i +
+          ', H=' +
+          newH +
+          ', W=' +
+          newW +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      function resizedEvent(i, newX, newY, newHPx, newWPx) {
+        const msg =
+          'RESIZED i=' +
+          i +
+          ', X=' +
+          newX +
+          ', Y=' +
+          newY +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      function containerResizedEvent(i, newH, newW, newHPx, newWPx) {
+        const msg =
+          'CONTAINER RESIZED i=' +
+          i +
+          ', H=' +
+          newH +
+          ', W=' +
+          newW +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      // Layout Event
+
+      function layoutCreatedEvent(newLayout) {
+        eventLog.value.push('Created layout');
+      }
+
+      function layoutReadyEvent(newLayout) {
+        eventLog.value.push('Ready layout');
+      }
+
+      function layoutUpdatedEvent(newLayout) {
+        eventLog.value.push('Updated layout');
+      }
+
+      // Layout Event
+
+      function layoutBeforeMountEvent(newLayout) {
+        eventLog.value.push('beforeMount layout');
+      }
+
+      function layoutMountedEvent(newLayout) {
+        eventLog.value.push('Mounted layout');
+      }
+
+      // Event
+
+      function moveEvent(i, newX, newY) {
+        const msg = 'MOVE i=' + i + ', X=' + newX + ', Y=' + newY;
+        eventLog.value.push(msg);
+      }
+
+      function movedEvent(i, newX, newY) {
+        const msg = 'MOVED i=' + i + ', X=' + newX + ', Y=' + newY;
+        eventLog.value.push(msg);
+      }
+
+      // Misc
+      const draggable = ref(true);
+      const index = ref(0);
+
+      return {
+        layout,
+        draggable,
+        resizable,
+        index,
+        eventLog,
+        eventsDiv,
+        moveEvent,
+        movedEvent,
+        resizeEvent,
+        resizedEvent,
+        containerResizedEvent,
+        layoutCreatedEvent,
+        layoutBeforeMountEvent,
+        layoutMountedEvent,
+        layoutReadyEvent,
+        layoutUpdatedEvent,
+      };
+    },
+  };
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .eventsJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+    height: 100px;
+    overflow-y: scroll;
+  }
+</style>

--- a/src/components/examples/Events.vue
+++ b/src/components/examples/Events.vue
@@ -43,9 +43,9 @@
 <script>
   import GridLayout from '@/components/GridLayout';
   import GridItem from '@/components/GridItem';
-  import { onMounted, ref, watch } from '@vue/composition-api';
+  import { defineComponent, onMounted, ref, watch } from '@vue/composition-api';
 
-  export default {
+  export default defineComponent({
     components: {
       GridLayout,
       GridItem,
@@ -203,7 +203,7 @@
         layoutUpdatedEvent,
       };
     },
-  };
+  });
 </script>
 
 <style scoped>

--- a/src/components/examples/Mirrored.stories.js
+++ b/src/components/examples/Mirrored.stories.js
@@ -1,0 +1,6 @@
+import Mirrored from './Mirrored.vue';
+export default { title: 'Examples' };
+export const asAComponentWithMirroredGridLayout = () => ({
+  components: { Mirrored },
+  template: `<Mirrored/>`,
+});

--- a/src/components/examples/Mirrored.vue
+++ b/src/components/examples/Mirrored.vue
@@ -1,0 +1,141 @@
+<template>
+  <div>
+    <input v-model="draggable" type="checkbox" /> Draggable
+    <input v-model="resizable" type="checkbox" /> Resizable
+    <input v-model="mirrored" type="checkbox" /> Mirrored
+    <br />
+    <grid-layout
+      :layout.sync="layout"
+      :col-num="12"
+      :row-height="30"
+      :is-draggable="draggable"
+      :is-resizable="resizable"
+      :is-mirrored="mirrored"
+      :vertical-compact="true"
+      :use-css-transforms="true"
+    >
+      <grid-item
+        v-for="(item, idx) in layout"
+        :key="idx"
+        :static="item.static"
+        :x="item.x"
+        :y="item.y"
+        :w="item.w"
+        :h="item.h"
+        :i="item.i"
+      >
+        <span class="text">{{ item.i }}</span>
+      </grid-item>
+    </grid-layout>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { ref, defineComponent } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0', static: false },
+        { x: 2, y: 0, w: 2, h: 4, i: '1', static: true },
+        { x: 4, y: 0, w: 2, h: 5, i: '2', static: false },
+        { x: 6, y: 0, w: 2, h: 3, i: '3', static: false },
+        { x: 8, y: 0, w: 2, h: 3, i: '4', static: false },
+        { x: 10, y: 0, w: 2, h: 3, i: '5', static: false },
+        { x: 0, y: 5, w: 2, h: 5, i: '6', static: false },
+        { x: 2, y: 5, w: 2, h: 5, i: '7', static: false },
+        { x: 4, y: 5, w: 2, h: 5, i: '8', static: false },
+        { x: 6, y: 3, w: 2, h: 4, i: '9', static: true },
+        { x: 8, y: 4, w: 2, h: 4, i: '10', static: false },
+        { x: 10, y: 4, w: 2, h: 4, i: '11', static: false },
+        { x: 0, y: 10, w: 2, h: 5, i: '12', static: false },
+        { x: 2, y: 10, w: 2, h: 5, i: '13', static: false },
+        { x: 4, y: 8, w: 2, h: 4, i: '14', static: false },
+        { x: 6, y: 8, w: 2, h: 4, i: '15', static: false },
+        { x: 8, y: 10, w: 2, h: 5, i: '16', static: false },
+        { x: 10, y: 4, w: 2, h: 2, i: '17', static: false },
+        { x: 0, y: 9, w: 2, h: 3, i: '18', static: false },
+        { x: 2, y: 6, w: 2, h: 2, i: '19', static: false },
+      ]);
+
+      const draggable = ref(true);
+      const resizable = ref(true);
+      const mirrored = ref(true);
+
+      return {
+        layout,
+        draggable,
+        resizable,
+        mirrored,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/examples/MultipleGrids.stories.js
+++ b/src/components/examples/MultipleGrids.stories.js
@@ -1,5 +1,5 @@
 import MultipleGrids from './MultipleGrids.vue';
-export default { title: 'Basic' };
+export default { title: 'Examples' };
 export const asAComponentWithMultipleGrids = () => ({
   components: { MultipleGrids },
   template: `<MultipleGrids/>`,

--- a/src/components/examples/MultipleGrids.stories.js
+++ b/src/components/examples/MultipleGrids.stories.js
@@ -1,0 +1,6 @@
+import MultipleGrids from './MultipleGrids.vue';
+export default { title: 'Basic' };
+export const asAComponentWithMultipleGrids = () => ({
+  components: { MultipleGrids },
+  template: `<MultipleGrids/>`,
+});

--- a/src/components/examples/MultipleGrids.vue
+++ b/src/components/examples/MultipleGrids.vue
@@ -1,0 +1,278 @@
+<template>
+  <div>
+    <div style="margin-top: 10px">
+      <h4>Grid #1</h4>
+      <grid-layout
+        :layout.sync="layout"
+        :col-num="12"
+        :row-height="30"
+        :is-draggable="true"
+        :is-resizable="true"
+        :vertical-compact="true"
+        :use-css-transforms="true"
+      >
+        <grid-item
+          v-for="(item, idx) in layout"
+          :key="idx"
+          :x="item.x"
+          :y="item.y"
+          :w="item.w"
+          :h="item.h"
+          :i="item.i"
+        >
+          <span class="text">{{ item.i }}</span>
+        </grid-item>
+      </grid-layout>
+    </div>
+    <div style="margin-top: 10px">
+      <h4>Grid #2</h4>
+      <grid-layout
+        :layout="layout2"
+        :col-num="12"
+        :row-height="30"
+        :is-draggable="true"
+        :is-resizable="true"
+        :vertical-compact="true"
+        :use-css-transforms="true"
+      >
+        <grid-item
+          v-for="(item, idx) in layout2"
+          :key="idx"
+          :x="item.x"
+          :y="item.y"
+          :w="item.w"
+          :h="item.h"
+          :i="item.i"
+        >
+          <span class="text">{{ item.i }}</span>
+        </grid-item>
+      </grid-layout>
+    </div>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { ref, watch } from '@vue/composition-api';
+
+  export default {
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      // Event Log
+      const eventLog = ref([]);
+
+      watch(
+        eventLog,
+        () => {
+          const eventsDiv = this.$refs.eventsDiv;
+          eventsDiv.scrollTop = eventsDiv.scrollHeight;
+        },
+        {
+          lazy: true,
+        },
+      );
+
+      //
+
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0' },
+        { x: 2, y: 0, w: 2, h: 4, i: '1' },
+      ]);
+
+      const layout2 = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0' },
+        { x: 2, y: 0, w: 2, h: 4, i: '1' },
+        { x: 4, y: 0, w: 2, h: 2, i: '2' },
+      ]);
+
+      const resizable = ref(true);
+      // Event Resized
+
+      function resizeEvent(i, newH, newW, newHPx, newWPx) {
+        const msg =
+          'RESIZE i=' +
+          i +
+          ', H=' +
+          newH +
+          ', W=' +
+          newW +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      function resizedEvent(i, newX, newY, newHPx, newWPx) {
+        const msg =
+          'RESIZED i=' +
+          i +
+          ', X=' +
+          newX +
+          ', Y=' +
+          newY +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      function containerResizedEvent(i, newH, newW, newHPx, newWPx) {
+        const msg =
+          'CONTAINER RESIZED i=' +
+          i +
+          ', H=' +
+          newH +
+          ', W=' +
+          newW +
+          ', H(px)=' +
+          newHPx +
+          ', W(px)=' +
+          newWPx;
+        eventLog.value.push(msg);
+      }
+
+      // Layout Event
+
+      function layoutCreatedEvent(newLayout) {
+        eventLog.value.push('Created layout');
+      }
+
+      function layoutReadyEvent(newLayout) {
+        eventLog.value.push('Ready layout');
+      }
+
+      function layoutUpdatedEvent(newLayout) {
+        eventLog.value.push('Updated layout');
+      }
+
+      // Layout Event
+
+      function layoutBeforeMountEvent(newLayout) {
+        eventLog.value.push('beforeMount layout');
+      }
+
+      function layoutMountedEvent(newLayout) {
+        eventLog.value.push('Mounted layout');
+      }
+
+      // Event
+
+      function moveEvent(i, newX, newY) {
+        const msg = 'MOVE i=' + i + ', X=' + newX + ', Y=' + newY;
+        eventLog.value.push(msg);
+      }
+
+      function movedEvent(i, newX, newY) {
+        const msg = 'MOVED i=' + i + ', X=' + newX + ', Y=' + newY;
+        eventLog.value.push(msg);
+      }
+
+      // Misc
+      const draggable = ref(true);
+      const index = ref(0);
+
+      return {
+        layout,
+        layout2,
+        draggable,
+        resizable,
+        index,
+        eventLog,
+        moveEvent,
+        movedEvent,
+        resizeEvent,
+        resizedEvent,
+        containerResizedEvent,
+        layoutCreatedEvent,
+        layoutBeforeMountEvent,
+        layoutMountedEvent,
+        layoutReadyEvent,
+        layoutUpdatedEvent,
+      };
+    },
+  };
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .eventsJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+    height: 100px;
+    overflow-y: scroll;
+  }
+</style>

--- a/src/components/examples/MultipleGrids.vue
+++ b/src/components/examples/MultipleGrids.vue
@@ -54,9 +54,9 @@
 <script>
   import GridLayout from '@/components/GridLayout';
   import GridItem from '@/components/GridItem';
-  import { ref, watch } from '@vue/composition-api';
+  import { defineComponent, ref, watch } from '@vue/composition-api';
 
-  export default {
+  export default defineComponent({
     components: {
       GridLayout,
       GridItem,
@@ -197,7 +197,7 @@
         layoutUpdatedEvent,
       };
     },
-  };
+  });
 </script>
 
 <style scoped>

--- a/src/components/examples/MultipleGrids.vue
+++ b/src/components/examples/MultipleGrids.vue
@@ -65,11 +65,11 @@
     setup() {
       // Event Log
       const eventLog = ref([]);
-
+      const eventsDiv = ref(null);
       watch(
         eventLog,
         () => {
-          const eventsDiv = this.$refs.eventsDiv;
+          const eventsDiv = eventsDiv.value;
           eventsDiv.scrollTop = eventsDiv.scrollHeight;
         },
         {

--- a/src/components/examples/PreventCollision.stories.js
+++ b/src/components/examples/PreventCollision.stories.js
@@ -1,0 +1,6 @@
+import PreventCollision from './PreventCollision.vue';
+export default { title: 'Examples' };
+export const asAComponentWithPreventCollision = () => ({
+  components: { PreventCollision },
+  template: `<PreventCollision/>`,
+});

--- a/src/components/examples/PreventCollision.vue
+++ b/src/components/examples/PreventCollision.vue
@@ -1,0 +1,136 @@
+<template>
+  <div>
+    <grid-layout
+      :layout.sync="layout"
+      :col-num="12"
+      :row-height="30"
+      :is-draggable="draggable"
+      :is-resizable="resizable"
+      :responsive="false"
+      :vertical-compact="false"
+      :prevent-collision="true"
+      :use-css-transforms="true"
+    >
+      <grid-item
+        v-for="(item, idx) in layout"
+        :key="idx"
+        :static="item.static"
+        :x="item.x"
+        :y="item.y"
+        :w="item.w"
+        :h="item.h"
+        :i="item.i"
+      >
+        <span class="text">{{ item.i }}</span>
+      </grid-item>
+    </grid-layout>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { ref, defineComponent } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0', static: false },
+        { x: 2, y: 0, w: 2, h: 4, i: '1', static: true },
+        { x: 4, y: 0, w: 2, h: 5, i: '2', static: false },
+        { x: 6, y: 0, w: 2, h: 3, i: '3', static: false },
+        { x: 8, y: 0, w: 2, h: 3, i: '4', static: false },
+        { x: 10, y: 0, w: 2, h: 3, i: '5', static: false },
+        { x: 0, y: 5, w: 2, h: 5, i: '6', static: false },
+        { x: 2, y: 5, w: 2, h: 5, i: '7', static: false },
+        { x: 4, y: 5, w: 2, h: 5, i: '8', static: false },
+        { x: 6, y: 3, w: 2, h: 4, i: '9', static: true },
+        { x: 8, y: 4, w: 2, h: 4, i: '10', static: false },
+        { x: 10, y: 4, w: 2, h: 4, i: '11', static: false },
+        { x: 0, y: 10, w: 2, h: 5, i: '12', static: false },
+        { x: 2, y: 10, w: 2, h: 5, i: '13', static: false },
+        { x: 4, y: 8, w: 2, h: 4, i: '14', static: false },
+        { x: 6, y: 8, w: 2, h: 4, i: '15', static: false },
+        { x: 8, y: 10, w: 2, h: 5, i: '16', static: false },
+        { x: 10, y: 4, w: 2, h: 2, i: '17', static: false },
+        { x: 0, y: 9, w: 2, h: 3, i: '18', static: false },
+        { x: 2, y: 6, w: 2, h: 2, i: '19', static: false },
+      ]);
+
+      const draggable = ref(true);
+      const resizable = ref(true);
+
+      return {
+        layout,
+        draggable,
+        resizable,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/examples/Responsive.stories.js
+++ b/src/components/examples/Responsive.stories.js
@@ -1,0 +1,6 @@
+import Responsive from './Responsive.vue';
+export default { title: 'Examples' };
+export const asAComponentWithResponsiveGridLayout = () => ({
+  components: { Responsive },
+  template: `<Responsive/>`,
+});

--- a/src/components/examples/Responsive.vue
+++ b/src/components/examples/Responsive.vue
@@ -1,0 +1,166 @@
+<template>
+  <div style="width: 100%; height: 2000px">
+    <div class="layoutJSON">
+      Displayed as <code>[x, y, w, h]</code>:
+      <div class="columns">
+        <div v-for="(item, idx) in layout" :key="idx">
+          <b>{{ item.i }}</b
+          >: [{{ item.x }}, {{ item.y }}, {{ item.w }}, {{ item.h }}]
+        </div>
+      </div>
+    </div>
+    <hr />
+    <input v-model="draggable" type="checkbox" /> Draggable
+    <input v-model="resizable" type="checkbox" /> Resizable
+    <input v-model="responsive" type="checkbox" /> Responsive
+    <br />
+    <div style="width: 100%; margin-top: 10px; height: 100%">
+      <grid-layout
+        :layout.sync="layout"
+        :col-num="12"
+        :row-height="30"
+        :is-draggable="draggable"
+        :is-resizable="resizable"
+        :responsive="responsive"
+        :vertical-compact="true"
+        :use-css-transforms="true"
+      >
+        <grid-item
+          v-for="(item, idx) in layout"
+          :key="idx"
+          :static="item.static"
+          :x="item.x"
+          :y="item.y"
+          :w="item.w"
+          :h="item.h"
+          :i="item.i"
+        >
+          <span class="text">{{ item.i }}</span>
+        </grid-item>
+      </grid-layout>
+    </div>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+  import { ref, defineComponent } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      const layout = ref([
+        { x: 0, y: 0, w: 2, h: 2, i: '0' },
+        { x: 2, y: 0, w: 2, h: 4, i: '1' },
+        { x: 4, y: 0, w: 2, h: 5, i: '2' },
+        { x: 6, y: 0, w: 2, h: 3, i: '3' },
+        { x: 8, y: 0, w: 2, h: 3, i: '4' },
+        { x: 10, y: 0, w: 2, h: 3, i: '5' },
+        { x: 0, y: 5, w: 2, h: 5, i: '6' },
+        { x: 2, y: 5, w: 2, h: 5, i: '7' },
+        { x: 4, y: 5, w: 2, h: 5, i: '8' },
+        { x: 6, y: 4, w: 2, h: 4, i: '9' },
+        { x: 8, y: 4, w: 2, h: 4, i: '10' },
+        { x: 10, y: 4, w: 2, h: 4, i: '11' },
+        { x: 0, y: 10, w: 2, h: 5, i: '12' },
+        { x: 2, y: 10, w: 2, h: 5, i: '13' },
+        { x: 4, y: 8, w: 2, h: 4, i: '14' },
+        { x: 6, y: 8, w: 2, h: 4, i: '15' },
+        { x: 8, y: 10, w: 2, h: 5, i: '16' },
+        { x: 10, y: 4, w: 2, h: 2, i: '17' },
+        { x: 0, y: 9, w: 2, h: 3, i: '18' },
+        { x: 2, y: 6, w: 2, h: 2, i: '19' },
+      ]);
+
+      const draggable = ref(true);
+      const resizable = ref(true);
+      const responsive = ref(true);
+
+      return {
+        layout,
+        draggable,
+        resizable,
+        responsive,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+
+  .layoutJSON {
+    background: #ddd;
+    border: 1px solid black;
+    margin-top: 10px;
+    padding: 10px;
+  }
+
+  .columns {
+    -moz-columns: 120px;
+    -webkit-columns: 120px;
+    columns: 120px;
+  }
+</style>

--- a/src/components/examples/ResponsivePredefinedLayouts.stories.js
+++ b/src/components/examples/ResponsivePredefinedLayouts.stories.js
@@ -1,0 +1,6 @@
+import ResponsivePredefinedLayouts from './ResponsivePredefinedLayouts.vue';
+export default { title: 'Examples' };
+export const asAComponentWithResponsivePredefinedLayouts = () => ({
+  components: { ResponsivePredefinedLayouts },
+  template: `<ResponsivePredefinedLayouts/>`,
+});

--- a/src/components/examples/ResponsivePredefinedLayouts.vue
+++ b/src/components/examples/ResponsivePredefinedLayouts.vue
@@ -1,0 +1,180 @@
+<template>
+  <div>
+    <grid-layout
+      :layout.sync="layout"
+      :responsive-layouts="layouts"
+      :col-num="12"
+      :row-height="30"
+      :is-draggable="draggable"
+      :is-resizable="resizable"
+      :vertical-compact="true"
+      :use-css-transforms="true"
+      :responsive="responsive"
+      @breakpoint-changed="breakpointChangedEvent"
+    >
+      <grid-item
+        v-for="(item, idx) in layout"
+        :key="idx"
+        :x="item.x"
+        :y="item.y"
+        :w="item.w"
+        :h="item.h"
+        :i="item.i"
+      >
+        <span class="text">{{ item.i }}</span>
+      </grid-item>
+    </grid-layout>
+  </div>
+</template>
+
+<script>
+  import GridLayout from '@/components/GridLayout';
+  import GridItem from '@/components/GridItem';
+
+  import { ref, reactive, defineComponent } from '@vue/composition-api';
+
+  export default defineComponent({
+    components: {
+      GridLayout,
+      GridItem,
+    },
+
+    setup() {
+      // Layouts Test
+
+      const testLayouts = reactive({
+        md: [
+          { x: 0, y: 0, w: 2, h: 2, i: '0' },
+          { x: 2, y: 0, w: 2, h: 4, i: '1' },
+          { x: 4, y: 0, w: 2, h: 5, i: '2' },
+          { x: 6, y: 0, w: 2, h: 3, i: '3' },
+          { x: 2, y: 4, w: 2, h: 3, i: '4' },
+          { x: 4, y: 5, w: 2, h: 3, i: '5' },
+          { x: 0, y: 2, w: 2, h: 5, i: '6' },
+          { x: 2, y: 7, w: 2, h: 5, i: '7' },
+          { x: 4, y: 8, w: 2, h: 5, i: '8' },
+          { x: 6, y: 3, w: 2, h: 4, i: '9' },
+          { x: 0, y: 7, w: 2, h: 4, i: '10' },
+          { x: 2, y: 19, w: 2, h: 4, i: '11' },
+          { x: 0, y: 14, w: 2, h: 5, i: '12' },
+          { x: 2, y: 14, w: 2, h: 5, i: '13' },
+          { x: 4, y: 13, w: 2, h: 4, i: '14' },
+          { x: 6, y: 7, w: 2, h: 4, i: '15' },
+          { x: 0, y: 19, w: 2, h: 5, i: '16' },
+          { x: 8, y: 0, w: 2, h: 2, i: '17' },
+          { x: 0, y: 11, w: 2, h: 3, i: '18' },
+          { x: 2, y: 12, w: 2, h: 2, i: '19' },
+        ],
+        lg: [
+          { x: 0, y: 0, w: 2, h: 2, i: '0' },
+          { x: 2, y: 0, w: 2, h: 4, i: '1' },
+          { x: 4, y: 0, w: 2, h: 5, i: '2' },
+          { x: 6, y: 0, w: 2, h: 3, i: '3' },
+          { x: 8, y: 0, w: 2, h: 3, i: '4' },
+          { x: 10, y: 0, w: 2, h: 3, i: '5' },
+          { x: 0, y: 5, w: 2, h: 5, i: '6' },
+          { x: 2, y: 5, w: 2, h: 5, i: '7' },
+          { x: 4, y: 5, w: 2, h: 5, i: '8' },
+          { x: 6, y: 4, w: 2, h: 4, i: '9' },
+          { x: 8, y: 4, w: 2, h: 4, i: '10' },
+          { x: 10, y: 4, w: 2, h: 4, i: '11' },
+          { x: 0, y: 10, w: 2, h: 5, i: '12' },
+          { x: 2, y: 10, w: 2, h: 5, i: '13' },
+          { x: 4, y: 8, w: 2, h: 4, i: '14' },
+          { x: 6, y: 8, w: 2, h: 4, i: '15' },
+          { x: 8, y: 10, w: 2, h: 5, i: '16' },
+          { x: 10, y: 4, w: 2, h: 2, i: '17' },
+          { x: 0, y: 9, w: 2, h: 3, i: '18' },
+          { x: 2, y: 6, w: 2, h: 2, i: '19' },
+        ],
+      });
+
+      const layouts = ref(testLayouts);
+      const layout = ref(testLayouts['lg']);
+      // Misc
+      const draggable = ref(true);
+      const resizable = ref(true);
+      const responsive = ref(true);
+
+      function breakpointChangedEvent(newBreakpoint, newLayout) {
+        console.log(
+          'BREAKPOINT CHANGED breakpoint=',
+          newBreakpoint,
+          ', layout: ',
+          newLayout,
+        );
+      }
+
+      return {
+        testLayouts,
+        layouts,
+        layout,
+        draggable,
+        resizable,
+        responsive,
+        breakpointChangedEvent,
+      };
+    },
+  });
+</script>
+
+<style scoped>
+  .vue-grid-layout {
+    background: #eee;
+  }
+
+  .vue-grid-item:not(.vue-grid-placeholder) {
+    background: #ccc;
+    border: 1px solid black;
+  }
+
+  .vue-grid-item .resizing {
+    opacity: 0.9;
+  }
+
+  .vue-grid-item .static {
+    background: #cce;
+  }
+
+  .vue-grid-item .text {
+    font-size: 24px;
+    text-align: center;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .no-drag {
+    height: 100%;
+    width: 100%;
+  }
+
+  .vue-grid-item .minMax {
+    font-size: 12px;
+  }
+
+  .vue-grid-item .add {
+    cursor: pointer;
+  }
+
+  .vue-draggable-handle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 0;
+    left: 0;
+    background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10'><circle cx='5' cy='5' r='5' fill='#999999'/></svg>")
+      no-repeat;
+    background-position: bottom right;
+    padding: 0 8px 8px 0;
+    background-repeat: no-repeat;
+    background-origin: content-box;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+</style>


### PR DESCRIPTION
- [x] Log events example. 

- [x] Multiple Grids example.
- [x] Drag Allow or Ignore on elements
- [x] Mirrored Grid layout
- [x] Responsive Grid layout
- [x] Prevent collision of grid items
- [x] Responsive pre-defined layout 
- [x] Dynamically add or remove grid items
- [x] Drag from outside